### PR TITLE
WebAssembly support

### DIFF
--- a/arith_wasm.s
+++ b/arith_wasm.s
@@ -1,0 +1,36 @@
+// Trampolines to math/big assembly implementations.
+
+#include "textflag.h"
+
+// func addVV(z, x, y []Word) (c Word)
+TEXT ·addVV(SB),NOSPLIT,$0
+    JMP math∕big·addVV(SB)
+
+// func subVV(z, x, y []Word) (c Word)
+TEXT ·subVV(SB),NOSPLIT,$0
+    JMP math∕big·subVV(SB)
+
+// func addVW(z, x []Word, y Word) (c Word)
+TEXT ·addVW(SB),NOSPLIT,$0
+    JMP math∕big·addVW(SB)
+
+// func subVW(z, x []Word, y Word) (c Word)
+TEXT ·subVW(SB),NOSPLIT,$0
+    JMP math∕big·subVW(SB)
+
+// func shlVU(z, x []Word, s uint) (c Word)
+TEXT ·shlVU(SB),NOSPLIT,$0
+    JMP math∕big·shlVU(SB)
+
+// func shrVU(z, x []Word, s uint) (c Word)
+TEXT ·shrVU(SB),NOSPLIT,$0
+    JMP math∕big·shrVU(SB)
+
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+    JMP math∕big·mulAddVWW(SB)
+
+// func addMulVVW(z, x []Word, y Word) (c Word)
+TEXT ·addMulVVW(SB),NOSPLIT,$0
+    JMP math∕big·addMulVVW(SB)
+


### PR DESCRIPTION
This pr enables cross compiling with `GOOS=js GOARCH=wasm` tests all pass... albeit it takes 10x as long and 15x the memory to run them under nodejs.