### PR TITLE
Add stubs for loong64 arithmetic routines

### DIFF
--- a/arith_loong64.s
+++ b/arith_loong64.s
@@ -1,0 +1,40 @@
+// Trampolines to math/big assembly implementations.
+
+// +build loong64
+
+#include "textflag.h"
+
+// func addVV(z, x, y []Word) (c Word)
+TEXT ·addVV(SB),NOSPLIT,$0
+	JMP	math∕big·addVV(SB)
+
+// func subVV(z, x, y []Word) (c Word)
+// (same as addVV except for SBBQ instead of ADCQ and label names)
+TEXT ·subVV(SB),NOSPLIT,$0
+	JMP	math∕big·subVV(SB)
+
+// func addVW(z, x []Word, y Word) (c Word)
+TEXT ·addVW(SB),NOSPLIT,$0
+	JMP	math∕big·addVW(SB)
+
+// func subVW(z, x []Word, y Word) (c Word)
+// (same as addVW except for SUBQ/SBBQ instead of ADDQ/ADCQ and label names)
+TEXT ·subVW(SB),NOSPLIT,$0
+	JMP	math∕big·subVW(SB)
+
+// func shlVU(z, x []Word, s uint) (c Word)
+TEXT ·shlVU(SB),NOSPLIT,$0
+	JMP	math∕big·shlVU(SB)
+
+// func shrVU(z, x []Word, s uint) (c Word)
+TEXT ·shrVU(SB),NOSPLIT,$0
+	JMP	math∕big·shrVU(SB)
+
+// func mulAddVWW(z, x []Word, y, r Word) (c Word)
+TEXT ·mulAddVWW(SB),NOSPLIT,$0
+	JMP	math∕big·mulAddVWW(SB)
+
+// func addMulVVW(z, x []Word, y Word) (c Word)
+TEXT ·addMulVVW(SB),NOSPLIT,$0
+	JMP	math∕big·addMulVVW(SB)
+


### PR DESCRIPTION
loong64 GOARCH value reserved for LoongArch architecture:
	https://golang.org/doc/go1.17.

github issues:
	https://github.com/golang/go/issues/46229

golang source code:
	https://github.com/loongson/go/tree/loong64-master

LoongArch documents:
	https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html

go test:
	=== RUN   TestCalibrateThreshold
	--- PASS: TestCalibrateThreshold (0.00s)
	=== RUN   TestCalibrateFFT
	--- PASS: TestCalibrateFFT (0.00s)
	=== RUN   TestFermatShift
	--- PASS: TestFermatShift (0.01s)
	=== RUN   TestFermatShiftHalf
	--- PASS: TestFermatShiftHalf (0.22s)
	=== RUN   TestFermatAdd
	--- PASS: TestFermatAdd (0.00s)
	=== RUN   TestFermatMul
	--- PASS: TestFermatMul (0.00s)
	=== RUN   TestRoundTripIntPoly
	--- PASS: TestRoundTripIntPoly (0.88s)
	=== RUN   TestFourierSizes
	--- PASS: TestFourierSizes (0.26s)
	=== RUN   TestFourier
	--- PASS: TestFourier (0.32s)
	=== RUN   TestRoundTripPolyValues
	--- PASS: TestRoundTripPolyValues (0.04s)
	=== RUN   TestMul
	--- PASS: TestMul (3.12s)
	=== RUN   TestIssue1
	--- PASS: TestIssue1 (0.01s)
	=== RUN   TestScan
	--- PASS: TestScan (14.74s)
	PASS
	ok      github.com/remyoudompheng/bigfft        19.607s